### PR TITLE
Implemented .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+/.editorconfig              export-ignore
+/.gitattributes             export-ignore
+/.gitignore                 export-ignore
+/.travis.yml                export-ignore
+/PULL_REQUEST_TEMPLATE.md   export-ignore
+/ISSUE_TEMPLATE.md          export-ignore
+/LICENSE.md                 export-ignore
+/README.md                  export-ignore
+/php-cd.php                 export-ignore
+/tests                      export-ignore
+/docs                       export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -10,6 +10,6 @@
 /ISSUE_TEMPLATE.md          export-ignore
 /LICENSE.md                 export-ignore
 /README.md                  export-ignore
-/php-cd.php                 export-ignore
+/.php-cs.php                 export-ignore
 /tests                      export-ignore
 /docs                       export-ignore


### PR DESCRIPTION
Added.gitattributes

The *.gitattributes* file lists the files and directories which SHOULDN'T be exported to the end user, for example; test files, example files, and markdown files.. Since these files are only used for development. They are not necessary and will only take up space in the end-users project.