### PR TITLE
[FEATURE] Added referenceCode (wc order number) property to reviews

### DIFF
--- a/src/JKetelaar/Kiyoh/Factory/ReviewFactory.php
+++ b/src/JKetelaar/Kiyoh/Factory/ReviewFactory.php
@@ -62,10 +62,11 @@ class ReviewFactory
         $comment = (isset($element->reviewComments) ? $element->reviewComments : '');
         $dateSince = $element->dateSince;
         $updatedSince = $element->updatedSince;
+        $referenceCode = $element->referenceCode;
 
         $content = self::createReviewContent($element->reviewContent->reviewContent);
 
-        $review = new Review($id, $author, $city, (float) $rating, $comment, $dateSince, $updatedSince);
+        $review = new Review($id, $author, $city, (float) $rating, $comment, $dateSince, $updatedSince, $referenceCode);
         $review->setContent($content);
 
         return $review;

--- a/src/JKetelaar/Kiyoh/Model/Review.php
+++ b/src/JKetelaar/Kiyoh/Model/Review.php
@@ -60,6 +60,7 @@ class Review
      * @param string $comment
      * @param string $dateSince
      * @param string $updatedSince
+     * @param string $referenceCode
      */
     public function __construct(
         string $id,
@@ -68,13 +69,15 @@ class Review
         float $rating,
         string $comment,
         string $dateSince,
-        string $updatedSince
+        string $updatedSince,
+        string $referenceCode
     ) {
         $this->id = $id;
         $this->author = $author;
         $this->city = $city;
         $this->rating = $rating;
         $this->comment = $comment;
+        $this->referenceCode = $referenceCode;
 
         try {
             $this->dateSince = new DateTime($dateSince);
@@ -281,6 +284,26 @@ class Review
     public function setUpdatedSince(DateTime $updatedSince): self
     {
         $this->updatedSince = $updatedSince;
+
+        return $this;
+    }
+
+    /**
+     * Retrieves the referenceCode from the  review.
+     * @return string
+     */
+    public function getReferenceCode(): string {
+        return $this->referenceCode;
+    }
+
+    /**
+     * @param string $referenceCode
+     *
+     * @return Review
+     */
+    public function setReferenceCode(string $referenceCode): self
+    {
+        $this->referenceCode = $referenceCode;
 
         return $this;
     }


### PR DESCRIPTION
Wij gebruiken het WooCommerce order nummer in onze app, waarmee we in een database bijhouden of de order een review mail heeft ontvangen en of er een review is achtergelaten. 
Dat wc-order nummer werd niet door deze package doorgegeven. Dat heb ik er nu ingebouwd.