### PR TITLE
Feature/support php8+fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "guzzlehttp/guzzle": "^6.2"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.16",
+        "friendsofphp/php-cs-fixer": "^3.13",
         "phpunit/phpunit": "^9.5"
     },
     "autoload": {

--- a/src/JKetelaar/Kiyoh/Factory/ReviewFactory.php
+++ b/src/JKetelaar/Kiyoh/Factory/ReviewFactory.php
@@ -22,28 +22,20 @@ class ReviewFactory
      */
     public static function createCompany(SimpleXMLElement $element): Company
     {
-        $averageRating = $element->averageRating;
-        $numberReviews = $element->numberReviews;
-        $last12MonthAverageRating = $element->last12MonthAverageRating;
-        $last12MonthNumberReviews = $element->last12MonthNumberReviews;
-        $percentageRecommendation = $element->percentageRecommendation;
-        $locationId = $element->locationId;
-        $locationName = $element->locationName;
-
         $company = new Company(
-            (float) $averageRating,
-            (int) $numberReviews,
-            (float) $last12MonthAverageRating,
-            (int) $last12MonthNumberReviews,
-            (int) $percentageRecommendation,
-            (int) $locationId,
-            $locationName
+            (float) $element->averageRating,
+            (int) $element->numberReviews,
+            (float) $element->last12MonthAverageRating,
+            (int) $element->last12MonthNumberReviews,
+            (int) $element->percentageRecommendation,
+            (int) $element->locationId,
+            (string) $element->locationName
         );
 
         $reviews = [];
 
         foreach ($element->reviews->reviews as $review) {
-            $reviews[] = (self::createReview($review));
+            $reviews[] = self::createReview($review);
         }
 
         $company->setReviews($reviews);
@@ -58,19 +50,17 @@ class ReviewFactory
      */
     public static function createReview(SimpleXMLElement $element): Review
     {
-        $id = $element->reviewId;
-        $author = $element->reviewAuthor;
-        $city = $element->city;
-        $rating = $element->rating;
-        $comment = (isset($element->reviewComments) ? $element->reviewComments : '');
-        $dateSince = $element->dateSince;
-        $updatedSince = $element->updatedSince;
-        $referenceCode = $element->referenceCode;
-
-        $content = self::createReviewContent($element->reviewContent->reviewContent);
-
-        $review = new Review($id, $author, $city, (float) $rating, $comment, $dateSince, $updatedSince, $referenceCode);
-        $review->setContent($content);
+        $review = new Review(
+            (string) $element->reviewId,
+            (string) $element->reviewAuthor,
+            (string) $element->city,
+            (float) $element->rating,
+            (isset($element->reviewComments) ? (string) $element->reviewComments : ''),
+            (string) $element->dateSince,
+            (string) $element->updatedSince,
+            (string) $element->referenceCode
+        );
+        $review->setContent(self::createReviewContent($element->reviewContent->reviewContent));
 
         return $review;
     }
@@ -85,13 +75,13 @@ class ReviewFactory
         $content = [];
 
         foreach ($elements as $element) {
-            $group = $element->questionGroup;
-            $type = $element->questionType;
-            $rating = $element->rating;
-            $order = $element->order;
-            $translation = $element->questionTranslation;
-
-            $content[] = new ReviewContent($group, $type, $rating, (int) $order, $translation);
+            $content[] = new ReviewContent(
+                (string) $element->questionGroup,
+                (string) $element->questionType,
+                (string) $element->rating,
+                (int) $element->order,
+                (string) $element->questionTranslation
+            );
         }
 
         return $content;

--- a/src/JKetelaar/Kiyoh/Factory/ReviewFactory.php
+++ b/src/JKetelaar/Kiyoh/Factory/ReviewFactory.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @author JKetelaar
  */

--- a/src/JKetelaar/Kiyoh/Kiyoh.php
+++ b/src/JKetelaar/Kiyoh/Kiyoh.php
@@ -14,7 +14,7 @@ use JKetelaar\Kiyoh\Model\Company;
 
 class Kiyoh
 {
-    const COMPANY_REVIEWS_URL = 'https://www.kiyoh.com/v1/review/feed.xml?hash=%s&limit=%s';
+    public const COMPANY_REVIEWS_URL = 'https://www.kiyoh.com/v1/review/feed.xml?hash=%s&limit=%s';
 
     /**
      * @var string

--- a/src/JKetelaar/Kiyoh/Kiyoh.php
+++ b/src/JKetelaar/Kiyoh/Kiyoh.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @author JKetelaar
  */

--- a/src/JKetelaar/Kiyoh/Model/Company.php
+++ b/src/JKetelaar/Kiyoh/Model/Company.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @author JKetelaar
  */

--- a/src/JKetelaar/Kiyoh/Model/Review.php
+++ b/src/JKetelaar/Kiyoh/Model/Review.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @author JKetelaar
  */

--- a/src/JKetelaar/Kiyoh/Model/Review.php
+++ b/src/JKetelaar/Kiyoh/Model/Review.php
@@ -295,7 +295,8 @@ class Review
      * Retrieves the referenceCode from the  review.
      * @return string
      */
-    public function getReferenceCode(): string {
+    public function getReferenceCode(): string
+    {
         return $this->referenceCode;
     }
 

--- a/src/JKetelaar/Kiyoh/Model/ReviewContent.php
+++ b/src/JKetelaar/Kiyoh/Model/ReviewContent.php
@@ -81,13 +81,13 @@ class ReviewContent
         $rating = $this->rating;
         switch ($this->getType()) {
             case 'INT':
-                $rating = intval($rating);
+                $rating = (int) $rating;
                 break;
             case 'BOOLEAN':
                 $rating = filter_var($rating, FILTER_VALIDATE_BOOLEAN);
                 break;
             default:
-                $rating = strval($rating);
+                $rating = (string) $rating;
                 break;
         }
 
@@ -106,7 +106,7 @@ class ReviewContent
                 $rating = $this->validateRating($rating);
                 break;
             default:
-                $rating = strval($rating);
+                $rating = (string) $rating;
                 break;
         }
         $this->rating = $rating;
@@ -141,11 +141,7 @@ class ReviewContent
      */
     private function validateRating(string $rating): string
     {
-        if (is_bool($rating)) {
-            return $rating ? 'true' : 'false';
-        } else {
-            return strval($rating);
-        }
+        return $rating;
     }
 
     /**

--- a/src/JKetelaar/Kiyoh/Model/ReviewContent.php
+++ b/src/JKetelaar/Kiyoh/Model/ReviewContent.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @author JKetelaar
  */

--- a/tests/Unit/KiyohTest.php
+++ b/tests/Unit/KiyohTest.php
@@ -13,8 +13,8 @@ use PHPUnit\Framework\TestCase;
 
 final class KiyohTest extends TestCase
 {
-    const KIYOH_KEY_ENV_KEY = 'KIYOH_KEY';
-    const REVIEW_COUNT = 5;
+    private const KIYOH_KEY_ENV_KEY = 'KIYOH_KEY';
+    private const REVIEW_COUNT = 5;
 
     public function testKiyoh()
     {

--- a/tests/Unit/KiyohTest.php
+++ b/tests/Unit/KiyohTest.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @author JKetelaar
  */
@@ -29,6 +32,6 @@ final class KiyohTest extends TestCase
 
         $reviews = $kiyoh->getCompany()->getReviews();
         $this->assertNotNull($reviews);
-        $this->assertEquals(self::REVIEW_COUNT, count($reviews));
+        $this->assertCount(self::REVIEW_COUNT, $reviews);
     }
 }


### PR DESCRIPTION
This is a further development upon the PHP8 MR ( #34 ) to cleanup some code.

I'd also like to propose and drop PHP7 support and move to constructor property promotion, readonly properties etc (and match-statement instead of the switch-case) to further clean it up and bring it up to par with modern PHP