### PR TITLE
Added Guzzle 7 or higher alongside the 6.x version 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "~7.3 || ^8.0",
         "ext-simplexml": "*",
-        "guzzlehttp/guzzle": "^6.2"
+        "guzzlehttp/guzzle": "^6.2 || ^7.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.13",


### PR DESCRIPTION
This is so it can support Drupal 10.